### PR TITLE
Fixed naming conflict that prevented IBM ILOG CPLEX to initialize in …

### DIFF
--- a/code/utils/Setfield.m
+++ b/code/utils/Setfield.m
@@ -1,5 +1,5 @@
 % obj holds the default value
-function obj = setfield(obj, source)
+function obj = Setfield(obj, source)
     key = fieldnames(obj);
     for i = 1:length(key)
         if isfield(source, key{i}) || isprop(source, key{i})


### PR DESCRIPTION
Dear all,

I identified the naming of the function setfield.m to create problems when intializing the IBM ILOG Cplex solver in the cobratoolbox. This is the result of a naming conflict with the Cplex object. I changed the name of this function to Setfield.m to solve this issue. I hope that you will accept this pull request. Please let me know if you have any concerns or questions.

Kind regards,
Tim Hensen (ORCID: https://orcid.org/0000-0003-2459-3755)