### PR TITLE
fix compiler: handle when there is space in path

### DIFF
--- a/code/solver/compile_solver.m
+++ b/code/solver/compile_solver.m
@@ -89,7 +89,7 @@ if (recompile)
    mex_string = [mex_string mex_string2];
    
    c = {};
-   c{end+1} = '%mex_string -output %outputfile %libpath/PackedChol.cpp %qdpath/util.cc %qdpath/bits.cc %qdpath/dd_real.cc %qdpath/dd_const.cc %qdpath/qd_real.cc %qdpath/qd_const.cc';
+   c{end+1} = '%mex_string -output "%outputfile" "%libpath/PackedChol.cpp" "%qdpath/util.cc" "%qdpath/bits.cc" "%qdpath/dd_real.cc" "%qdpath/dd_const.cc" "%qdpath/qd_real.cc" "%qdpath/qd_const.cc"';
    
    %% replace keywords
    keywords = {'%mex_string', '%qdpath', '%libpath', '%outputfile'};


### PR DESCRIPTION
Previously, `compiler_solver.m` was unable to compile files when spaces were present in the path. `compile_solver.m` has now been modified to handle this case.